### PR TITLE
实现一个自定义的ClassLoader

### DIFF
--- a/src/main/java/com/github/hcsp/classloader/MyClassLoader.java
+++ b/src/main/java/com/github/hcsp/classloader/MyClassLoader.java
@@ -1,6 +1,10 @@
 package com.github.hcsp.classloader;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class MyClassLoader extends ClassLoader {
     // 存放字节码文件的目录
@@ -25,7 +29,19 @@ public class MyClassLoader extends ClassLoader {
     // 扩展阅读：ClassLoader类的Javadoc文档
     @Override
     protected Class<?> findClass(String name) throws ClassNotFoundException {
-        throw new ClassNotFoundException(name);
+        Path path = Paths.get(name + ".class");
+        byte[] b;
+        if (Files.exists(path)) {
+            try {
+                b = Files.readAllBytes(path);
+            } catch (IOException e) {
+                throw new ClassNotFoundException(name);
+            }
+        } else {
+            throw new ClassNotFoundException(name);
+        }
+
+        return defineClass(name, b, 0, b.length);
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
双亲委派加载模型并不是强制的,java推荐在实现ClassLoader
时优先交给父亲处理,这里我们并没有调用父类的super.findClass

<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

